### PR TITLE
Fix server startup and flashcard routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "firebase-admin": "^13.3.0",
-    "openai": "^4.90.0"
+    "openai": "^4.90.0",
+    "axios": "^1.6.1",
+    "cheerio": "^1.0.0-rc.12"
   }
 }

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const express     = require('express');
 const cors        = require('cors');
 const killTrigger = require('./middleware/killTrigger');
 const admin = require("firebase-admin");
+const { getFirestore } = require('firebase-admin/firestore');
 
 admin.initializeApp({
   credential: admin.credential.cert({
@@ -12,6 +13,7 @@ admin.initializeApp({
     privateKey: process.env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, '\n'),
   }),
 });
+const db = getFirestore();
 
 
 
@@ -369,8 +371,8 @@ Return a JSON array of up to 3 objects: [{ excerpt: "...", source: "essay/recomm
   }
 });
 
-// ── AI Flashcards Endpoint ──
-app.post('/api/flashcards', async (req, res) => {
+// ── AI Flashcards by Weakest Topic ──
+app.post('/api/flashcards-topic', async (req, res) => {
   try {
     const uid  = req.body.uid;      // from client
     const test = req.body.test;     // 'shsat' | 'isee' | 'sat'
@@ -611,8 +613,8 @@ app.post('/api/subscribe-insurance', async (req, res) => {
   res.json({ success:true });
 });
 
-// ── Flashcard Generation Endpoint ──
-app.post('/api/flashcards', async (req, res) => {
+// ── Flashcards from Lesson Text ──
+app.post('/api/flashcards-text', async (req, res) => {
   const { text } = req.body;
   const prompt = `
 Extract up to 5 Q&A flashcards from this lesson text:
@@ -688,6 +690,7 @@ Return JSON array: [ { "q":"…", "choices":["A","B","C","D"], "answer":"A" }, �
 });
 
 // replace your existing app.listen with http.listen so Socket.IO works:
+const PORT = process.env.PORT || 5000;
 http.listen(PORT, () => console.log(`🌐 Server live on port ${PORT}`));
 
 // ── Adaptive Drill by Test Type ──
@@ -757,7 +760,7 @@ app.get('/api/forecast-score', async (req, res) => {
 });
 
 // ── Flashcard Generator (Spaced‑Repetition) ──
-app.post('/api/flashcards', async (req, res) => {
+app.post('/api/flashcards-spaced', async (req, res) => {
   const { uid, testType } = req.body;
   try {
     // pull recent wrong items for this user & test
@@ -1005,8 +1008,4 @@ app.post('/flashcard', async (req, res) => {
 
 
 
-// Ensure your server actually starts
-const PORT = process.env.PORT || 5000;
-app.listen(PORT, () => {
-  console.log(`🚀 Server running on http://localhost:${PORT}`);
-});
+// Server started above with http.listen()


### PR DESCRIPTION
## Summary
- initialize Firestore client in server
- give each flashcard route a unique path
- start the app once with `http.listen`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f78a3909083279ed1fac4933d97f4